### PR TITLE
sluggish/invisible keyframes animation when both translateX transforms are being applied

### DIFF
--- a/Shared/Components/PersonCard/PersonCard.razor
+++ b/Shared/Components/PersonCard/PersonCard.razor
@@ -1,21 +1,24 @@
 ﻿@namespace TailBlazor.Shared.Components
 
-<div class="personCard">
+@if(Person is not null)
+{
+    <div class="personCard">
 
-    <div class="flex justify-between h-1/4 p-2
-              bg-secondary-100 dark:bg-primary-700 border-b-2 border-accent-100
-                rounded-t-lg md:rounded-t-xl">
+        <div class="flex justify-between h-1/4 p-2
+                bg-secondary-100 dark:bg-primary-700 border-b-2 border-accent-100
+                    rounded-t-lg md:rounded-t-xl">
 
-        <div class="p-1 md:p-2 text-xl md:text-3xl self-center">@Person.Image</div>
+            <div class="p-1 md:p-2 text-xl md:text-3xl self-center">@Person.Image</div>
 
-        <div class="pr-2 md:pr-4 font-bold text-2xl right-2 overflow-hidden self-center" >@Person.Name</div>
+            <div class="pr-2 md:pr-4 font-bold text-2xl right-2 overflow-hidden self-center" >@Person.Name</div>
+        </div>
+
+        <p class="px-3 pt-2 text-sm md:text-base italic line-clamp-5">@Person.Bio</p>
+
     </div>
-
-    <p class="px-2 pt-2 text-sm md:text-base italic line-clamp-5">@Person.Bio</p>
-
-</div>
+}
 
 @code
 {
-    [Parameter] public Person Person { get; set; }
+    [Parameter] public Person? Person { get; set; }
 }

--- a/Shared/Components/PersonCard/PersonCard.razor.css
+++ b/Shared/Components/PersonCard/PersonCard.razor.css
@@ -4,4 +4,5 @@
   @apply md:shadow-md md:rounded-xl md:h-64 md:w-96 md:m-4;
   @apply ring-2 hover:ring-4 ring-accent-300;
   @apply transition-all duration-300;
+  backface-visibility: hidden;
 }

--- a/Shared/Pages/Index.razor
+++ b/Shared/Pages/Index.razor
@@ -34,6 +34,6 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
-         people = (await PersonService.GetPeopleAsync(50)).ToArray();
+         people = (await PersonService!.GetPeopleAsync(30))?.ToArray();
     }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
             keyframes: {
                 hscroll: {
                     '0%': { transform: 'translateX(10vw)' },
-                    '50%': { transform: 'translateX(-100%) translateX(90vw)' },
+                    '50%': { transform: 'translateX(calc(90vw - 100%))' },
                     '100%': { transform: 'translateX(10vw)' },
                 }
             },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = {
                 }
             },
             animation: {
-                hscroll: 'hscroll 800s infinite linear',
+                hscroll: 'hscroll 300s infinite linear',
             }
         },
     },


### PR DESCRIPTION
Fixes #2

Stacking transforms wasn't the issue.  I thought it had something to do with that as the issue happened when `-100%` was "done".  But, TIL: "The + and - operators must be surrounded by whitespace." (The reason i was stacking transforms was the calc() i originally used did not include whitespace and failed.)

The "fix" provided by [StackOverflow](https://stackoverflow.com/questions/3461441/prevent-flicker-on-webkit-transition-of-webkit-transform): `backface-visibility: hidden;`  IDK why it works or if it is the correct or best fix, but it works.
