### PR TITLE
better-builds

### DIFF
--- a/.github/workflows/azure-static-web-apps-polite-sky-006af1d1e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-sky-006af1d1e.yml
@@ -39,8 +39,8 @@ jobs:
       #     npm install
       #     npm run publish-wasm
 
-      # - name: Publish Site
-      #   run: dotnet publish ./StaticWebAppsDemo/BlazorWasm -c Release
+      - name: Publish Site
+        run: dotnet publish ./StaticWebAppsDemo/BlazorWasm -c Release
 
       - name: Build And Deploy
         id: builddeploy
@@ -52,8 +52,7 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          # app_location: "./StaticWebAppsDemo/BlazorWasm/bin/Release/publish/wwwroot" # App source code path
-          app_location: "./StaticWebAppsDemo/BlazorWasm/" # App source code path
+          app_location: "./StaticWebAppsDemo/BlazorWasm/bin/Release/publish/wwwroot" # App source code path
           api_location: "./StaticWebAppsDemo/FunctionsAPI" # Api source code path - optional
           output_location: "wwwroot" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######

--- a/.github/workflows/azure-static-web-apps-polite-sky-006af1d1e.yml
+++ b/.github/workflows/azure-static-web-apps-polite-sky-006af1d1e.yml
@@ -24,23 +24,23 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
-      - name: Install Node 16
-        uses: actions/setup-node@v2
-        with:
-          node-version: "16"
+      # - name: Install Node 16
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: "16"
 
-      - name: Build Razor CSS
-        run: dotnet build ./StaticWebAppsDemo/BlazorWasm -c Release
+      # - name: Build Razor CSS
+      #   run: dotnet build ./StaticWebAppsDemo/BlazorWasm -c Release
 
-      - name: Build Tailwind CSS
-        run: |
-          cd ./StaticWebAppsDemo/
-          npm install -g npm@latest
-          npm install
-          npm run publish-wasm
+      # - name: Build Tailwind CSS
+      #   run: |
+      #     cd ./StaticWebAppsDemo/
+      #     npm install -g npm@latest
+      #     npm install
+      #     npm run publish-wasm
 
-      - name: Publish Site
-        run: dotnet publish ./StaticWebAppsDemo/BlazorWasm -c Release
+      # - name: Publish Site
+      #   run: dotnet publish ./StaticWebAppsDemo/BlazorWasm -c Release
 
       - name: Build And Deploy
         id: builddeploy
@@ -52,7 +52,8 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "./StaticWebAppsDemo/BlazorWasm/bin/Release/publish/wwwroot" # App source code path
+          # app_location: "./StaticWebAppsDemo/BlazorWasm/bin/Release/publish/wwwroot" # App source code path
+          app_location: "./StaticWebAppsDemo/BlazorWasm/" # App source code path
           api_location: "./StaticWebAppsDemo/FunctionsAPI" # Api source code path - optional
           output_location: "wwwroot" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.nupkg
 **/*.min.css
 local/**
+**/.vs/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
   "omnisharp.enableImportCompletion": true,
   "omnisharp.enableRoslynAnalyzers": true,
   "csharp.semanticHighlighting.enabled": true,
-  "csharp.suppressHiddenDiagnostics": false
+  "csharp.suppressHiddenDiagnostics": false,
+  "azureFunctions.projectSubpath": "StaticWebAppsDemo/FunctionsAPI"
 }

--- a/StaticWebAppsDemo/.vscode/launch.json
+++ b/StaticWebAppsDemo/.vscode/launch.json
@@ -32,18 +32,18 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
-      "name": "WASM ONLY: Watch",
+      "name": "Client: Watch",
       "type": "coreclr",
       "request": "launch",
       "program": "dotnet",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "preLaunchTask": "wasm - build & watch tailwind",
+      "preLaunchTask": "dotnet build & watch tailwind",
       "postDebugTask": "stop wasm watch",
       "args": [
         "watch",
         "run",
-        "-- -property TailwindBuild=false"
+        "-- -p:TailwindBuild=false"
       ],
       "cwd": "${workspaceFolder}/BlazorWasm",
       "presentation": {
@@ -52,11 +52,11 @@
       }
     },
     {
-      "name": "WASM ONLY: Debug",
+      "name": "Client: Debug",
       "type": "blazorwasm",
       "request": "launch",
       "cwd": "${workspaceFolder}/BlazorWasm",
-      "preLaunchTask": "wasm - build & watch tailwind",
+      "preLaunchTask": "dotnet build & watch tailwind",
       "postDebugTask": "stop wasm watch",
       "presentation": {
         "close": true,
@@ -67,10 +67,10 @@
   ],
   "compounds": [
     {
-      "name": "WASM+API: Watch",
+      "name": "API & Client: Watch",
       "configurations": [
         "API: Watch",
-        "WASM ONLY: Watch"
+        "Client: Watch"
       ],
       "presentation": {
         "group": "0",
@@ -79,10 +79,10 @@
       "stopAll": true
     },
     {
-      "name": "WASM+API: Debug",
+      "name": "API & Client: Debug",
       "configurations": [
         "API: Debug",
-        "WASM ONLY: Debug"
+        "Client: Debug"
       ],
       "presentation": {
         "group": "0",

--- a/StaticWebAppsDemo/.vscode/launch.json
+++ b/StaticWebAppsDemo/.vscode/launch.json
@@ -19,18 +19,18 @@
         "close": true
       }
     },
-    {
-      "name": "API: Debug",
-      "type": "coreclr",
-      "request": "attach",
-      "processId": "${command:azureFunctions.pickProcess}",
-      "cwd": "${workspaceFolder}/FunctionsAPI",
-      "presentation": {
-        "group": "1",
-        "close": true
-      },
-      "internalConsoleOptions": "neverOpen"
-    },
+    // {
+    //   "name": "API: Debug",
+    //   "type": "coreclr",
+    //   "request": "attach",
+    //   "processId": "${command:azureFunctions.pickProcess}",
+    //   "cwd": "${workspaceFolder}/FunctionsAPI",
+    //   "presentation": {
+    //     "group": "1",
+    //     "close": true
+    //   },
+    //   "internalConsoleOptions": "neverOpen"
+    // },
     {
       "name": "Client: Watch",
       "type": "coreclr",
@@ -39,7 +39,7 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "preLaunchTask": "dotnet build & watch tailwind",
-      "postDebugTask": "stop wasm watch",
+      "postDebugTask": "stop watching",
       "args": [
         "watch",
         "run",
@@ -51,19 +51,19 @@
         "group": "2"
       }
     },
-    {
-      "name": "Client: Debug",
-      "type": "blazorwasm",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/BlazorWasm",
-      "preLaunchTask": "dotnet build & watch tailwind",
-      "postDebugTask": "stop wasm watch",
-      "presentation": {
-        "close": true,
-        "group": "2"
-      },
-      "internalConsoleOptions": "neverOpen"
-    },
+    // {
+    //   "name": "Client: Debug",
+    //   "type": "blazorwasm",
+    //   "request": "launch",
+    //   "cwd": "${workspaceFolder}/BlazorWasm",
+    //   "preLaunchTask": "dotnet build & watch tailwind",
+    //   "postDebugTask": "stop watching",
+    //   "presentation": {
+    //     "close": true,
+    //     "group": "2"
+    //   },
+    //   "internalConsoleOptions": "neverOpen"
+    // },
   ],
   "compounds": [
     {
@@ -78,17 +78,17 @@
       },
       "stopAll": true
     },
-    {
-      "name": "API & Client: Debug",
-      "configurations": [
-        "API: Debug",
-        "Client: Debug"
-      ],
-      "presentation": {
-        "group": "0",
-        "close": true,
-      },
-      "stopAll": true
-    }
+    // {
+    //   "name": "API & Client: Debug",
+    //   "configurations": [
+    //     "API: Debug",
+    //     "Client: Debug"
+    //   ],
+    //   "presentation": {
+    //     "group": "0",
+    //     "close": true,
+    //   },
+    //   "stopAll": true
+    // }
   ]
 }

--- a/StaticWebAppsDemo/.vscode/tasks.json
+++ b/StaticWebAppsDemo/.vscode/tasks.json
@@ -14,9 +14,9 @@
       "group": "build"
     },
     {
-      "label": "wasm - build & watch tailwind",
+      "label": "dotnet build & watch tailwind",
       "type": "shell",
-      "command": "dotnet build -property TailwindBuild=false && npm run watch-wasm",
+      "command": "dotnet build -p:TailwindBuild=false && npm run watch",
       "isBackground": true,
       "presentation": {
         "echo": false,
@@ -27,52 +27,17 @@
     },
     {
       "label": "stop wasm watch",
-      "command": "echo ${input:terminate-wasm}",
+      "command": "echo ${input:terminate}",
       "type": "shell",
       "problemMatcher": []
     },
-    {
-      "label": "server - build & watch tailwind",
-      "type": "shell",
-      "command": "dotnet build -property TailwindBuild=false && npm run watch-server",
-      "isBackground": true,
-      "presentation": {
-        "echo": false,
-        "reveal": "never",
-        "panel": "shared",
-        "clear": true
-      },
-    },
-    {
-      "label": "stop server watch",
-      "command": "echo ${input:terminate-server}",
-      "type": "shell",
-      "problemMatcher": []
-    }
-    // {
-    //   "label": "delay",
-    //   "type": "shell",
-    //   "command": "sleep 2",
-    //   "presentation": {
-    //     "echo": false,
-    //     "reveal": "never",
-    //     "panel": "shared",
-    //     "clear": true
-    //   }
-    // },
   ],
   "inputs": [
     {
       "id": "terminate-wasm",
       "type": "command",
       "command": "workbench.action.tasks.terminate",
-      "args": "wasm - build & watch tailwind"
-    },
-    {
-      "id": "terminate-server",
-      "type": "command",
-      "command": "workbench.action.tasks.terminate",
-      "args": "server - build & watch tailwind"
+      "args": "dotnet build & watch tailwind"
     }
   ]
 }

--- a/StaticWebAppsDemo/.vscode/tasks.json
+++ b/StaticWebAppsDemo/.vscode/tasks.json
@@ -11,7 +11,8 @@
         "panel": "shared",
         "clear": true
       },
-      "group": "build"
+      "group": "build",
+      "problemMatcher": "$msCompile"
     },
     {
       "label": "dotnet build & watch tailwind",
@@ -23,18 +24,18 @@
         "reveal": "never",
         "panel": "shared",
         "clear": true
-      },
+      }
     },
     {
-      "label": "stop wasm watch",
+      "label": "stop watching",
       "command": "echo ${input:terminate}",
       "type": "shell",
-      "problemMatcher": []
+      "problemMatcher": "$msCompile"
     },
   ],
   "inputs": [
     {
-      "id": "terminate-wasm",
+      "id": "terminate",
       "type": "command",
       "command": "workbench.action.tasks.terminate",
       "args": "dotnet build & watch tailwind"

--- a/StaticWebAppsDemo/BlazorWasm/tailwindcss.targets
+++ b/StaticWebAppsDemo/BlazorWasm/tailwindcss.targets
@@ -12,6 +12,7 @@
     </Target>
     <Target Name="tailwind build" AfterTargets="AfterBuild" Condition="'$(TailwindBuild)' == 'true'">
         <Message Text="tailwind build target running..." Importance="high"></Message>
-        <Exec Command="npm run build" />
+        <Exec Command="npm run build" Condition="'$(Configuration)' == 'Debug'"/>
+        <Exec Command="npm run publish" Condition="'$(Configuration)' == 'Release'"/>
     </Target>
 </Project>

--- a/StaticWebAppsDemo/BlazorWasm/tailwindcss.targets
+++ b/StaticWebAppsDemo/BlazorWasm/tailwindcss.targets
@@ -6,12 +6,12 @@
         <Exec Command="npm -v" ContinueOnError="true">
             <Output TaskParameter="ExitCode" PropertyName="error" />
         </Exec>
-        <Error Condition="'$(error)' != '0'" Text="install npm please !" />
+        <Error Condition="'$(error)' != '0'" Text="install node.js please !" />
         <Exec Command="npm install" />
         <Touch Files="../node_modules/.install-stamp" AlwaysCreate="true" />
     </Target>
     <Target Name="tailwind build" AfterTargets="AfterBuild" Condition="'$(TailwindBuild)' == 'true'">
         <Message Text="tailwind build target running..." Importance="high"></Message>
-        <Exec Command="npm run build-wasm" Condition="'$(Configuration)' == 'Debug'"/>
+        <Exec Command="npm run build" Condition="'$(Configuration)' == 'Debug'"/>
     </Target>
 </Project>

--- a/StaticWebAppsDemo/BlazorWasm/tailwindcss.targets
+++ b/StaticWebAppsDemo/BlazorWasm/tailwindcss.targets
@@ -12,6 +12,6 @@
     </Target>
     <Target Name="tailwind build" AfterTargets="AfterBuild" Condition="'$(TailwindBuild)' == 'true'">
         <Message Text="tailwind build target running..." Importance="high"></Message>
-        <Exec Command="npm run build" Condition="'$(Configuration)' == 'Debug'"/>
+        <Exec Command="npm run build" />
     </Target>
 </Project>

--- a/StaticWebAppsDemo/package.json
+++ b/StaticWebAppsDemo/package.json
@@ -9,9 +9,9 @@
     "tailwindcss-debug-screens": "^2.2.0"
   },
   "scripts": {
-    "build-wasm": "npx tailwindcss --config tailwind.config.js --postcss postcss.config.js -i StaticWebAppsDemo.css -o ./BlazorWasm/wwwroot/StaticWebAppsDemo.min.css",
-    "watch-wasm": "npx tailwindcss --watch --config tailwind.config.js --postcss postcss.config.js -i StaticWebAppsDemo.css -o ./BlazorWasm/wwwroot/StaticWebAppsDemo.min.css",
-    "publish-wasm": "npx tailwindcss --minify --config tailwind.config.js --postcss postcss.config.js -i StaticWebAppsDemo.css -o ./BlazorWasm/wwwroot/StaticWebAppsDemo.min.css"
+    "build": "npx tailwindcss --config tailwind.config.js --postcss postcss.config.js -i StaticWebAppsDemo.css -o ./BlazorWasm/wwwroot/StaticWebAppsDemo.min.css",
+    "watch": "npx tailwindcss --watch --config tailwind.config.js --postcss postcss.config.js -i StaticWebAppsDemo.css -o ./BlazorWasm/wwwroot/StaticWebAppsDemo.min.css",
+    "publish": "npx tailwindcss --minify --config tailwind.config.js --postcss postcss.config.js -i StaticWebAppsDemo.css -o ./BlazorWasm/wwwroot/StaticWebAppsDemo.min.css"
   },
   "keywords": [
     "tailwindcss",

--- a/StaticWebAppsDemo/watch.ps1
+++ b/StaticWebAppsDemo/watch.ps1
@@ -1,8 +1,8 @@
-# dotnet build -- -property TailwindBuild=false  # [wonky things](https://github.com/dotnet/aspnetcore/issues/34500) can happen without explicit pre-build - fixed in RC1 (?)
 start "dotnet" -ArgumentList "watch --project ./FunctionsAPI msbuild /t:RunFunctions" # -NoNewWindow
 sleep 1
-start "dotnet" -ArgumentList "watch --project ./BlazorWasm/BlazorWasm.csproj run -- --property:TailwindBuild=false" # -NoNewWindow
+cd "BlazorWasm"
+start "dotnet" -ArgumentList "watch -- run --property:TailwindBuild=false" # -NoNewWindow
 
-while (!(Test-Path "./BlazorWasm/obj/scopedcss/bundle/BlazorWasm.styles.css")) { sleep -ms 200 } # tailwind needs this file
+while (!(Test-Path "./obj/scopedcss/bundle/BlazorWasm.styles.css")) { sleep -ms 200 } # tailwind needs this file
 
 npm run watch

--- a/StaticWebAppsDemo/watch.ps1
+++ b/StaticWebAppsDemo/watch.ps1
@@ -5,4 +5,4 @@ start "dotnet" -ArgumentList "watch --project ./BlazorWasm/BlazorWasm.csproj run
 
 while (!(Test-Path "./BlazorWasm/obj/scopedcss/bundle/BlazorWasm.styles.css")) { sleep -ms 200 } # tailwind needs this file
 
-npm  run watch-wasm
+npm run watch

--- a/StaticWebAppsDemo/watch.ps1
+++ b/StaticWebAppsDemo/watch.ps1
@@ -1,7 +1,7 @@
 start "dotnet" -ArgumentList "watch --project ./FunctionsAPI msbuild /t:RunFunctions" # -NoNewWindow
 sleep 1
 cd "BlazorWasm"
-start "dotnet" -ArgumentList "watch -- run --property:TailwindBuild=false" # -NoNewWindow
+start "dotnet" -ArgumentList "watch -- run -p:TailwindBuild=false" # -NoNewWindow
 
 while (!(Test-Path "./obj/scopedcss/bundle/BlazorWasm.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Full/.vscode/launch.json
+++ b/Templates/Full/.vscode/launch.json
@@ -13,7 +13,7 @@
       "args": [
         "watch",
         "run",
-        "-- -property TailwindBuild=false"
+        "-- -p:TailwindBuild=false"
       ],
       "cwd": "${workspaceFolder}/BlazorWasm",
       "presentation": {
@@ -44,7 +44,7 @@
       "args": [
         "watch",
         "run",
-        "-- -property TailwindBuild=false"
+        "-- -p:TailwindBuild=false"
       ],
       "cwd": "${workspaceFolder}/BlazorServer",
       "presentation": {

--- a/Templates/Full/.vscode/tasks.json
+++ b/Templates/Full/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "wasm - build & watch tailwind",
       "type": "shell",
-      "command": "dotnet build -property TailwindBuild=false && npm run watch-wasm",
+      "command": "dotnet build -p:TailwindBuild=false && npm run watch-wasm",
       "isBackground": true,
       "presentation": {
         "echo": false,
@@ -34,7 +34,7 @@
     {
       "label": "server - build & watch tailwind",
       "type": "shell",
-      "command": "dotnet build -property TailwindBuild=false && npm run watch-server",
+      "command": "dotnet build -p:TailwindBuild=false && npm run watch-server",
       "isBackground": true,
       "presentation": {
         "echo": false,

--- a/Templates/Full/.vscode/tasks.json
+++ b/Templates/Full/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "wasm - build & watch tailwind",
       "type": "shell",
-      "command": "dotnet build -p:TailwindBuild=false && npm run watch-wasm",
+      "command": "dotnet build -p:TailwindBuild=false && npm run watch",
       "isBackground": true,
       "presentation": {
         "echo": false,
@@ -34,7 +34,7 @@
     {
       "label": "server - build & watch tailwind",
       "type": "shell",
-      "command": "dotnet build -p:TailwindBuild=false && npm run watch-server",
+      "command": "dotnet build -p:TailwindBuild=false && npm run watch",
       "isBackground": true,
       "presentation": {
         "echo": false,

--- a/Templates/Full/BlazorServer/Pages/Error.cshtml
+++ b/Templates/Full/BlazorServer/Pages/Error.cshtml
@@ -7,7 +7,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <link rel="stylesheet" href="css/TailBlazor.min.css" />
+    <link rel="stylesheet" href="_content/RazorClassLibrary/TailBlazor.min.css" />
     <title>Error</title>
 </head>
 

--- a/Templates/Full/BlazorServer/Pages/_Host.cshtml
+++ b/Templates/Full/BlazorServer/Pages/_Host.cshtml
@@ -12,7 +12,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Server</title>
-    <link rel="stylesheet" href="/TailBlazor.min.css" />
+    <link rel="stylesheet" href="/_content/RazorClassLibrary/TailBlazor.min.css" />
     <base href="/" />
 </head>
 

--- a/Templates/Full/BlazorServer/watch-server.ps1
+++ b/Templates/Full/BlazorServer/watch-server.ps1
@@ -1,4 +1,4 @@
-start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -NoNewWindow
+start "dotnet" -ArgumentList "watch -- run -p:TailwindBuild=false" # -NoNewWindow
 
 while (!(Test-Path "../RazorClassLibrary/obj/scopedcss/bundle/RazorClassLibrary.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Full/BlazorServer/watch-server.ps1
+++ b/Templates/Full/BlazorServer/watch-server.ps1
@@ -1,4 +1,4 @@
-start "dotnet" -ArgumentList "watch run -- -property TailwindBuild=false" # -NoNewWindow
+start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -NoNewWindow
 
 while (!(Test-Path "../RazorClassLibrary/obj/scopedcss/bundle/RazorClassLibrary.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Full/BlazorWasm/watch-wasm.ps1
+++ b/Templates/Full/BlazorWasm/watch-wasm.ps1
@@ -1,5 +1,4 @@
-# dotnet build -- -property TailwindBuild=false  # [wonky things](https://github.com/dotnet/aspnetcore/issues/34500) can happen without explicit pre-build - fixed in RC1 (?)
-start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -NoNewWindow
+start "dotnet" -ArgumentList "watch -- run -p:TailwindBuild=false" # -NoNewWindow
 
 while (!(Test-Path "../RazorClassLibrary/obj/scopedcss/bundle/RazorClassLibrary.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Full/BlazorWasm/watch-wasm.ps1
+++ b/Templates/Full/BlazorWasm/watch-wasm.ps1
@@ -1,5 +1,5 @@
 # dotnet build -- -property TailwindBuild=false  # [wonky things](https://github.com/dotnet/aspnetcore/issues/34500) can happen without explicit pre-build - fixed in RC1 (?)
-start "dotnet" -ArgumentList "watch run -- -property TailwindBuild=false" # -NoNewWindow
+start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -NoNewWindow
 
 while (!(Test-Path "../RazorClassLibrary/obj/scopedcss/bundle/RazorClassLibrary.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Full/BlazorWasm/wwwroot/index.html
+++ b/Templates/Full/BlazorWasm/wwwroot/index.html
@@ -7,7 +7,10 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title>Client</title>
-    <link rel="stylesheet" href="./TailBlazor.min.css" />
+    <link
+      rel="stylesheet"
+      href="./_content/RazorClassLibrary/TailBlazor.min.css"
+    />
     <base href="/" />
   </head>
 

--- a/Templates/Full/RazorClassLibrary/tailwindcss.targets
+++ b/Templates/Full/RazorClassLibrary/tailwindcss.targets
@@ -12,9 +12,6 @@
     </Target>
     <Target Name="tailwind build" AfterTargets="AfterBuild" Condition="'$(TailwindBuild)' == 'true'">
         <Message Text="tailwind build target running..." Importance="high"></Message>
-        <Exec Command="npm run build-server" Condition="'$(Configuration)' == 'Debug'"/>
-        <Exec Command="npm run build-wasm" Condition="'$(Configuration)' == 'Debug'"/>
-        <!-- <Exec Command="npm run build-maui" Condition="'$(Configuration)' == 'Debug'"/>
-        <Exec Command="npm run build-pages" Condition="'$(Configuration)' == 'Debug'"/> -->
+        <Exec Command="npm run build" Condition="'$(Configuration)' == 'Debug'"/>
     </Target>
 </Project>

--- a/Templates/Full/RazorClassLibrary/tailwindcss.targets
+++ b/Templates/Full/RazorClassLibrary/tailwindcss.targets
@@ -6,7 +6,7 @@
         <Exec Command="npm -v" ContinueOnError="true">
             <Output TaskParameter="ExitCode" PropertyName="error" />
         </Exec>
-        <Error Condition="'$(error)' != '0'" Text="install npm please !" />
+        <Error Condition="'$(error)' != '0'" Text="install node.js please !" />
         <Exec Command="npm install" />
         <Touch Files="../node_modules/.install-stamp" AlwaysCreate="true" />
     </Target>

--- a/Templates/Full/package.json
+++ b/Templates/Full/package.json
@@ -7,12 +7,9 @@
     "tailwindcss": "^3.0.0-alpha.2"
   },
   "scripts": {
-    "build-wasm": "npx tailwindcss --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./BlazorWasm/wwwroot/TailBlazor.min.css",
-    "watch-wasm": "npx tailwindcss --watch --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./BlazorWasm/wwwroot/TailBlazor.min.css",
-    "publish-wasm": "npx tailwindcss --minify --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./BlazorWasm/wwwroot/TailBlazor.min.css",
-    "build-server": "npx tailwindcss --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./BlazorServer/wwwroot/TailBlazor.min.css",
-    "watch-server": "npx tailwindcss --watch --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./BlazorServer/wwwroot/TailBlazor.min.css",
-    "publish-server": "npx tailwindcss --minify --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./BlazorServer/wwwroot/TailBlazor.min.css"
+    "build": "npx tailwindcss --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./RazorClassLibrary/wwwroot/TailBlazor.min.css",
+    "watch": "npx tailwindcss --watch --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./RazorClassLibrary/wwwroot/TailBlazor.min.css",
+    "publish": "npx tailwindcss --minify --config tailwind.config.js --postcss postcss.config.js -i TailBlazor.css -o ./RazorClassLibrary/wwwroot/TailBlazor.min.css"
   },
   "keywords": [
     "tailwindcss",

--- a/Templates/Minimal/TailBlazorServer/.vscode/launch.json
+++ b/Templates/Minimal/TailBlazorServer/.vscode/launch.json
@@ -19,13 +19,6 @@
         "close": true,
       },
       "internalConsoleOptions": "neverOpen"
-    },
-    // {
-    //   "name": "Debug",
-    //   "type": "blazorwasm",
-    //   "request": "launch",
-    //   "cwd": "${workspaceFolder}/",
-    //   "preLaunchTask": "build",
-    // },
+    }
   ]
 }

--- a/Templates/Minimal/TailBlazorServer/.vscode/tasks.json
+++ b/Templates/Minimal/TailBlazorServer/.vscode/tasks.json
@@ -1,18 +1,6 @@
 {
   "version": "2.0.0",
   "tasks": [
-    // {
-    //   "label": "build",
-    //   "type": "shell",
-    //   "command": "dotnet build",
-    //   "presentation": {
-    //     "echo": false,
-    //     "reveal": "silent",
-    //     "panel": "shared",
-    //     "clear": true
-    //   },
-    //   "group": "build"
-    // },
     {
       "label": "dotnet build & watch tailwind",
       "type": "shell",

--- a/Templates/Minimal/TailBlazorServer/Components/DarkSwitch/DarkSwitch.razor
+++ b/Templates/Minimal/TailBlazorServer/Components/DarkSwitch/DarkSwitch.razor
@@ -1,4 +1,4 @@
-@namespace TailBlazorWasm.Components
+@namespace TailBlazorServer.Components
 
 @* <fluent-switch title="toggle dark mode" @onclick="switchTheme" current-checked=isLightMode /> *@
 

--- a/Templates/Minimal/TailBlazorServer/Components/DarkSwitch/DarkSwitch.razor.cs
+++ b/Templates/Minimal/TailBlazorServer/Components/DarkSwitch/DarkSwitch.razor.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
-namespace TailBlazorWasm.Components;
+namespace TailBlazorServer.Components;
 
 public partial class DarkSwitch : ComponentBase
 {

--- a/Templates/Minimal/TailBlazorServer/tailwindcss.targets
+++ b/Templates/Minimal/TailBlazorServer/tailwindcss.targets
@@ -6,7 +6,7 @@
         <Exec Command="npm -v" ContinueOnError="true">
             <Output TaskParameter="ExitCode" PropertyName="error" />
         </Exec>
-        <Error Condition="'$(error)' != '0'" Text="install npm please !" />
+        <Error Condition="'$(error)' != '0'" Text="install node.js please !" />
         <Exec Command="npm install"/>
         <Touch Files="node_modules/.install-stamp" AlwaysCreate="true" />
     </Target>

--- a/Templates/Minimal/TailBlazorServer/watch.ps1
+++ b/Templates/Minimal/TailBlazorServer/watch.ps1
@@ -1,4 +1,4 @@
-start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -nonewwindow
+start "dotnet" -ArgumentList "watch -- run -p:TailwindBuild=false" # -nonewwindow
 
 while (!(Test-Path "./obj/scopedcss/bundle/TailBlazorServer.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Minimal/TailBlazorServer/watch.ps1
+++ b/Templates/Minimal/TailBlazorServer/watch.ps1
@@ -1,4 +1,4 @@
-start "dotnet" -ArgumentList "watch run -- -property TailwindBuild=false" # -nonewwindow
+start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -nonewwindow
 
 while (!(Test-Path "./obj/scopedcss/bundle/TailBlazorServer.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Minimal/TailBlazorWasm/.vscode/launch.json
+++ b/Templates/Minimal/TailBlazorWasm/.vscode/launch.json
@@ -10,7 +10,7 @@
       "args": [
         "watch",
         "run",
-        "-- -property TailwindBuild=false"
+        "-- -p:TailwindBuild=false"
       ],
       "cwd": "${workspaceFolder}/",
       "preLaunchTask": "build & start tailwind jit/watch",

--- a/Templates/Minimal/TailBlazorWasm/.vscode/tasks.json
+++ b/Templates/Minimal/TailBlazorWasm/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "build & start tailwind jit/watch",
       "type": "shell",
-      "command": "dotnet build -property TailwindBuild=false && npm run watch",
+      "command": "dotnet build -p:TailwindBuild=false && npm run watch",
       "isBackground": true,
       "presentation": {
         "echo": false,

--- a/Templates/Minimal/TailBlazorWasm/tailwindcss.targets
+++ b/Templates/Minimal/TailBlazorWasm/tailwindcss.targets
@@ -6,7 +6,7 @@
         <Exec Command="npm -v" ContinueOnError="true">
             <Output TaskParameter="ExitCode" PropertyName="error" />
         </Exec>
-        <Error Condition="'$(error)' != '0'" Text="install npm please !" />
+        <Error Condition="'$(error)' != '0'" Text="install node.js please !" />
         <Exec Command="npm install"/>
         <Touch Files="node_modules/.install-stamp" AlwaysCreate="true" />
     </Target>

--- a/Templates/Minimal/TailBlazorWasm/watch.ps1
+++ b/Templates/Minimal/TailBlazorWasm/watch.ps1
@@ -1,4 +1,4 @@
-start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -nonewwindow
+start "dotnet" -ArgumentList "watch -- run -p:TailwindBuild=false" # -nonewwindow
 
 while (!(Test-Path "./obj/scopedcss/bundle/TailBlazorWasm.styles.css")) { sleep -ms 200 } # tailwind needs this file
 

--- a/Templates/Minimal/TailBlazorWasm/watch.ps1
+++ b/Templates/Minimal/TailBlazorWasm/watch.ps1
@@ -1,4 +1,4 @@
-start "dotnet" -ArgumentList "watch run -- -property TailwindBuild=false" # -nonewwindow
+start "dotnet" -ArgumentList "watch -- run --property TailwindBuild=false" # -nonewwindow
 
 while (!(Test-Path "./obj/scopedcss/bundle/TailBlazorWasm.styles.css")) { sleep -ms 200 } # tailwind needs this file
 


### PR DESCRIPTION
* apply TailwindBuild=false with short-form `-p:` as `run` expects `--property` and build expects `-property` as long form.
* ensure vscode launch configs/tasks for watch and `watch.ps1` scripts are correct
* switch RCL package to use Static Assets aka wwwroot and consuming projects point to it - "_content/RazorClassLibrary/..."